### PR TITLE
Refactor/code refactoring #5

### DIFF
--- a/iOSEngineerCodeCheck/Presenter/SearchRepositoryPresenter.swift
+++ b/iOSEngineerCodeCheck/Presenter/SearchRepositoryPresenter.swift
@@ -42,7 +42,7 @@ extension SearchRepositoryPresenter: SearchRepositoryPresenterInput {
 }
 
 extension SearchRepositoryPresenter {
-    // APIのURLを構築
+
     private func createAPIURL(for searchKeyword: String) -> URL? {
         guard let apiURL = URL(string: "https://api.github.com/search/repositories?q=\(searchKeyword)") else {
             return nil
@@ -50,7 +50,6 @@ extension SearchRepositoryPresenter {
         return apiURL
     }
 
-    // URLセッション
     private func urlSession(apiURL: URL) {
         let urlSessionTask = URLSession.shared.dataTask(with: apiURL) { (data, _, error) in
 
@@ -69,7 +68,6 @@ extension SearchRepositoryPresenter {
         urlSessionTask.resume()
     }
 
-    // データのパース処理
     private func parseRepositoryData(data: Data) {
         do {
             if let json = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],

--- a/iOSEngineerCodeCheck/Presenter/SearchRepositoryPresenter.swift
+++ b/iOSEngineerCodeCheck/Presenter/SearchRepositoryPresenter.swift
@@ -60,13 +60,13 @@ extension SearchRepositoryPresenter {
                 return
             }
             
-            self.parseData(data: data)
+            self.parseRepositoryData(data: data)
         }
         urlSessionTask.resume()
     }
 
     // データのパース処理
-    private func parseData(data: Data) {
+    private func parseRepositoryData(data: Data) {
         do {
             if let json = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
                let items = json["items"] as? [[String: Any]] {

--- a/iOSEngineerCodeCheck/Presenter/SearchRepositoryPresenter.swift
+++ b/iOSEngineerCodeCheck/Presenter/SearchRepositoryPresenter.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 protocol SearchRepositoryPresenterInput {
-    func searchRepositories(SearchKeyword: String)
+    func searchRepositories(searchKeyword: String)
 }
 
 protocol SearchRepositoryPresenterOutput: AnyObject {
@@ -28,57 +28,78 @@ final class SearchRepositoryPresenter {
 }
 
 extension SearchRepositoryPresenter: SearchRepositoryPresenterInput {
+    func searchRepositories(searchKeyword: String) {
 
-    func searchRepositories(SearchKeyword searchKeyword: String) {
-        if let apiURL = URL(string: "https://api.github.com/search/repositories?q=\(searchKeyword)") {
-            let urlSessionTask = URLSession.shared.dataTask(with: apiURL) { (data, _, error) in
+        if let apiURL = createAPIURL(for: searchKeyword) {
+            urlSession(apiURL: apiURL)
+        }
 
-                if let error = error {
-                    print("リクエスト失敗: \(error.localizedDescription)")
-                    return
-                }
+    }
+}
 
-                guard let data = data else {
-                    print("データがありません")
-                    return
-                }
+extension SearchRepositoryPresenter {
+    // APIのURLを構築
+    private func createAPIURL(for searchKeyword: String) -> URL? {
+        guard let apiURL = URL(string: "https://api.github.com/search/repositories?q=\(searchKeyword)") else {
+            return nil
+        }
+        return apiURL
+    }
 
-                do {
-                    if let json = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
-                       let items = json["items"] as? [[String: Any]] {
-                        let repositories = items.compactMap { item in
-                            if let fullName = item["full_name"] as? String,
-                               let language = item["language"] as? String,
-                               let stargazersCount = item["stargazers_count"] as? Int,
-                               let watchersCount = item["watchers_count"] as? Int,
-                               let forksCount = item["forks_count"] as? Int,
-                               let openIssuesCount = item["open_issues_count"] as? Int,
-                               let owner = item["owner"] as? [String: Any],
-                               let stringImageURL = owner["avatar_url"] as? String,
-                               let imageURL = URL(string: stringImageURL) {
+    // URLセッション
+    private func urlSession(apiURL: URL) {
+        let urlSessionTask = URLSession.shared.dataTask(with: apiURL) { (data, _, error) in
 
-                                return RepositoryModel(
-                                    fullName: fullName,
-                                    language: language,
-                                    stargazersCount: stargazersCount,
-                                    watchersCount: watchersCount,
-                                    forksCount: forksCount,
-                                    openIssuesCount: openIssuesCount,
-                                    avatarURL: imageURL
-                                )
-                            }
-                            return nil
-                        }
-                        self.output?.reloadData(repositories: repositories)
-                        print("リクエスト成功")
-                    } else {
-                        print("パースエラー")
-                    }
-                } catch {
-                    print("パースエラー: \(error.localizedDescription)")
-                }
+            guard let data = data else {
+                print("データがありません")
+                return
             }
-            urlSessionTask.resume()
+
+            if let error = error {
+                print("リクエスト失敗: \(error.localizedDescription)")
+                return
+            }
+            
+            self.parseData(data: data)
+        }
+        urlSessionTask.resume()
+    }
+
+    // データのパース処理
+    private func parseData(data: Data) {
+        do {
+            if let json = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
+               let items = json["items"] as? [[String: Any]] {
+                let repositories = items.compactMap { item in
+                    if let fullName = item["full_name"] as? String,
+                       let language = item["language"] as? String,
+                       let stargazersCount = item["stargazers_count"] as? Int,
+                       let watchersCount = item["watchers_count"] as? Int,
+                       let forksCount = item["forks_count"] as? Int,
+                       let openIssuesCount = item["open_issues_count"] as? Int,
+                       let owner = item["owner"] as? [String: Any],
+                       let stringImageURL = owner["avatar_url"] as? String,
+                       let imageURL = URL(string: stringImageURL) {
+
+                        return RepositoryModel(
+                            fullName: fullName,
+                            language: language,
+                            stargazersCount: stargazersCount,
+                            watchersCount: watchersCount,
+                            forksCount: forksCount,
+                            openIssuesCount: openIssuesCount,
+                            avatarURL: imageURL
+                        )
+                    }
+                    return nil
+                }
+                self.output?.reloadData(repositories: repositories)
+                print("リクエスト成功")
+            } else {
+                print("パースエラー")
+            }
+        } catch {
+            print("パースエラー")
         }
     }
 }

--- a/iOSEngineerCodeCheck/Presenter/SearchRepositoryPresenter.swift
+++ b/iOSEngineerCodeCheck/Presenter/SearchRepositoryPresenter.swift
@@ -10,6 +10,8 @@ import Foundation
 
 protocol SearchRepositoryPresenterInput {
     func searchRepositories(searchKeyword: String)
+    func cancelURLSession()
+
 }
 
 protocol SearchRepositoryPresenterOutput: AnyObject {
@@ -19,6 +21,7 @@ protocol SearchRepositoryPresenterOutput: AnyObject {
 final class SearchRepositoryPresenter {
     private weak var output: SearchRepositoryPresenterOutput!
     private var repositories: [RepositoryModel]
+    private var urlSessionTask: URLSessionTask?
 
     init(output: SearchRepositoryPresenterOutput!) {
         self.output = output
@@ -35,6 +38,11 @@ extension SearchRepositoryPresenter: SearchRepositoryPresenterInput {
         }
 
     }
+
+    func cancelURLSession() {
+        urlSessionTask?.cancel()
+    }
+
 }
 
 extension SearchRepositoryPresenter {

--- a/iOSEngineerCodeCheck/Presenter/SearchRepositoryPresenter.swift
+++ b/iOSEngineerCodeCheck/Presenter/SearchRepositoryPresenter.swift
@@ -11,7 +11,6 @@ import Foundation
 protocol SearchRepositoryPresenterInput {
     func searchRepositories(searchKeyword: String)
     func cancelURLSession()
-
 }
 
 protocol SearchRepositoryPresenterOutput: AnyObject {
@@ -27,22 +26,19 @@ final class SearchRepositoryPresenter {
         self.output = output
         self.repositories = []
     }
-
 }
 
 extension SearchRepositoryPresenter: SearchRepositoryPresenterInput {
-    func searchRepositories(searchKeyword: String) {
 
+    func searchRepositories(searchKeyword: String) {
         if let apiURL = createAPIURL(for: searchKeyword) {
             urlSession(apiURL: apiURL)
         }
-
     }
 
     func cancelURLSession() {
         urlSessionTask?.cancel()
     }
-
 }
 
 extension SearchRepositoryPresenter {

--- a/iOSEngineerCodeCheck/View/DetailRepositoryViewController.swift
+++ b/iOSEngineerCodeCheck/View/DetailRepositoryViewController.swift
@@ -24,13 +24,7 @@ class DetailRepositoryViewController: UIViewController {
         super.viewDidLoad()
         
         if let selectedRowIndex = parentController.selectedRowIndex {
-            let repository = parentController.repositories[selectedRowIndex]
-            repositoryTitleView.text = repository.fullName
-            languageLabel.text = "Written in \(repository.language)"
-            StarsCountLabel.text = "\(repository.stargazersCount) stars"
-            watchersCountLabel.text = "\(repository.watchersCount) watchers"
-            forksCountLabel.text = "\(repository.forksCount) forks"
-            issuesCountLabel.text = "\(repository.openIssuesCount) open issues"
+            updateUI(selectedRowIndex)
             getImage()
         }
         
@@ -38,6 +32,16 @@ class DetailRepositoryViewController: UIViewController {
 }
 
 extension DetailRepositoryViewController {
+
+    private func updateUI(_ selectedRowIndex: Int) {
+        let repository = parentController.repositories[selectedRowIndex]
+        repositoryTitleView.text = repository.fullName
+        languageLabel.text = "Written in \(repository.language)"
+        StarsCountLabel.text = "\(repository.stargazersCount) stars"
+        watchersCountLabel.text = "\(repository.watchersCount) watchers"
+        forksCountLabel.text = "\(repository.forksCount) forks"
+        issuesCountLabel.text = "\(repository.openIssuesCount) open issues"
+    }
     
     private func getImage(){
         if let selectedRowIndex = parentController.selectedRowIndex {

--- a/iOSEngineerCodeCheck/View/DetailRepositoryViewController.swift
+++ b/iOSEngineerCodeCheck/View/DetailRepositoryViewController.swift
@@ -35,6 +35,9 @@ class DetailRepositoryViewController: UIViewController {
         }
         
     }
+}
+
+extension DetailRepositoryViewController {
     
     private func getImage(){
         if let selectedRowIndex = parentController.selectedRowIndex {

--- a/iOSEngineerCodeCheck/View/DetailRepositoryViewController.swift
+++ b/iOSEngineerCodeCheck/View/DetailRepositoryViewController.swift
@@ -36,7 +36,7 @@ class DetailRepositoryViewController: UIViewController {
         
     }
     
-    func getImage(){
+    private func getImage(){
         if let selectedRowIndex = parentController.selectedRowIndex {
             let repository = parentController.repositories[selectedRowIndex]
             

--- a/iOSEngineerCodeCheck/View/DetailRepositoryViewController.swift
+++ b/iOSEngineerCodeCheck/View/DetailRepositoryViewController.swift
@@ -25,7 +25,7 @@ class DetailRepositoryViewController: UIViewController {
         
         if let selectedRowIndex = parentController.selectedRowIndex {
             updateUI(selectedRowIndex)
-            getImage()
+            getImage(selectedRowIndex)
         }
         
     }
@@ -43,24 +43,26 @@ extension DetailRepositoryViewController {
         issuesCountLabel.text = "\(repository.openIssuesCount) open issues"
     }
     
-    private func getImage(){
-        if let selectedRowIndex = parentController.selectedRowIndex {
-            let repository = parentController.repositories[selectedRowIndex]
-            
-            let imageURL = repository.avatarURL
-            URLSession.shared.dataTask(with: imageURL) { (data, _, error) in
-                if let data = data, let image = UIImage(data: data) {
-                    DispatchQueue.main.async {
-                        self.repositoryImageView.image = image
-                    }
-                } else {
-                    print("画像取得エラー")
-                }
-                if let error = error {
-                    print("画像取得エラー: \(error.localizedDescription)")
-                }
-            }.resume()
-        }
+    private func getImage(_ selectedRowIndex: Int){
+        let repository = parentController.repositories[selectedRowIndex]
+        let imageURL = repository.avatarURL
+        parseImageData(imageURL)
     }
+
+    private func parseImageData(_ imageURL: URL) {
+        URLSession.shared.dataTask(with: imageURL) { (data, _, error) in
+            if let data = data, let image = UIImage(data: data) {
+                DispatchQueue.main.async {
+                    self.repositoryImageView.image = image
+                }
+            } else {
+                print("画像取得エラー")
+            }
+            if let error = error {
+                print("画像取得エラー: \(error.localizedDescription)")
+            }
+        }.resume()
+    }
+
 }
 

--- a/iOSEngineerCodeCheck/View/DetailRepositoryViewController.swift
+++ b/iOSEngineerCodeCheck/View/DetailRepositoryViewController.swift
@@ -27,7 +27,6 @@ class DetailRepositoryViewController: UIViewController {
             updateUI(selectedRowIndex)
             getImage(selectedRowIndex)
         }
-        
     }
 }
 
@@ -51,6 +50,7 @@ extension DetailRepositoryViewController {
 
     private func parseImageData(_ imageURL: URL) {
         URLSession.shared.dataTask(with: imageURL) { (data, _, error) in
+
             if let data = data, let image = UIImage(data: data) {
                 DispatchQueue.main.async {
                     self.repositoryImageView.image = image
@@ -58,6 +58,7 @@ extension DetailRepositoryViewController {
             } else {
                 print("画像取得エラー")
             }
+            
             if let error = error {
                 print("画像取得エラー: \(error.localizedDescription)")
             }

--- a/iOSEngineerCodeCheck/View/SearchRepositoryViewController.swift
+++ b/iOSEngineerCodeCheck/View/SearchRepositoryViewController.swift
@@ -12,9 +12,7 @@ final class SearchRepositoryViewController: UITableViewController{
     @IBOutlet weak var searchBar: UISearchBar!
 
     private var presenter: SearchRepositoryPresenterInput!
-
     var repositories: [RepositoryModel] = []
-    var urlSessionTask: URLSessionTask?
     var selectedRowIndex: Int?
 
     override func viewDidLoad() {
@@ -42,7 +40,7 @@ extension SearchRepositoryViewController: UISearchBarDelegate {
     }
 
     internal func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
-        urlSessionTask?.cancel()
+        presenter.cancelURLSession()
     }
 
     internal func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {

--- a/iOSEngineerCodeCheck/View/SearchRepositoryViewController.swift
+++ b/iOSEngineerCodeCheck/View/SearchRepositoryViewController.swift
@@ -48,7 +48,7 @@ extension SearchRepositoryViewController: UISearchBarDelegate {
 
     internal func searchRepository() {
         guard let searchKeyword = searchBar.text, searchKeyword.count != 0 else { return }
-        presenter?.searchRepositories(searchKeyword: searchKeyword)
+        presenter.searchRepositories(searchKeyword: searchKeyword)
     }
 }
 

--- a/iOSEngineerCodeCheck/View/SearchRepositoryViewController.swift
+++ b/iOSEngineerCodeCheck/View/SearchRepositoryViewController.swift
@@ -19,8 +19,16 @@ final class SearchRepositoryViewController: UITableViewController{
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        setupSearchBar()
+        setupPresenter()
+    }
+
+    private func setupSearchBar() {
         searchBar.text = "GitHubのリポジトリを検索できるよー"
         searchBar.delegate = self
+    }
+
+    private func setupPresenter() {
         presenter = SearchRepositoryPresenter(output: self)
     }
 }

--- a/iOSEngineerCodeCheck/View/SearchRepositoryViewController.swift
+++ b/iOSEngineerCodeCheck/View/SearchRepositoryViewController.swift
@@ -38,6 +38,10 @@ extension SearchRepositoryViewController: UISearchBarDelegate {
     }
 
     func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
+        searchRepository()
+    }
+
+    func searchRepository() {
         guard let searchKeyword = searchBar.text, searchKeyword.count != 0 else { return }
         presenter?.searchRepositories(SearchKeyword: searchKeyword)
     }

--- a/iOSEngineerCodeCheck/View/SearchRepositoryViewController.swift
+++ b/iOSEngineerCodeCheck/View/SearchRepositoryViewController.swift
@@ -36,20 +36,20 @@ final class SearchRepositoryViewController: UITableViewController{
 extension SearchRepositoryViewController: UISearchBarDelegate {
 
 
-    func searchBarShouldBeginEditing(_ searchBar: UISearchBar) -> Bool {
+    internal func searchBarShouldBeginEditing(_ searchBar: UISearchBar) -> Bool {
         searchBar.text = ""
         return true
     }
 
-    func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
+    internal func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
         urlSessionTask?.cancel()
     }
 
-    func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
+    internal func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
         searchRepository()
     }
 
-    func searchRepository() {
+    internal func searchRepository() {
         guard let searchKeyword = searchBar.text, searchKeyword.count != 0 else { return }
         presenter?.searchRepositories(searchKeyword: searchKeyword)
     }
@@ -83,7 +83,7 @@ extension SearchRepositoryViewController {
 }
 
 extension SearchRepositoryViewController: SearchRepositoryPresenterOutput {
-    func reloadData(repositories: [RepositoryModel]) {
+    internal func reloadData(repositories: [RepositoryModel]) {
         self.repositories = repositories
         DispatchQueue.main.async {
             self.tableView.reloadData()

--- a/iOSEngineerCodeCheck/View/SearchRepositoryViewController.swift
+++ b/iOSEngineerCodeCheck/View/SearchRepositoryViewController.swift
@@ -51,7 +51,7 @@ extension SearchRepositoryViewController: UISearchBarDelegate {
 
     func searchRepository() {
         guard let searchKeyword = searchBar.text, searchKeyword.count != 0 else { return }
-        presenter?.searchRepositories(SearchKeyword: searchKeyword)
+        presenter?.searchRepositories(searchKeyword: searchKeyword)
     }
 }
 

--- a/iOSEngineerCodeCheck/View/SearchRepositoryViewController.swift
+++ b/iOSEngineerCodeCheck/View/SearchRepositoryViewController.swift
@@ -33,7 +33,6 @@ final class SearchRepositoryViewController: UITableViewController{
 
 extension SearchRepositoryViewController: UISearchBarDelegate {
 
-
     internal func searchBarShouldBeginEditing(_ searchBar: UISearchBar) -> Bool {
         searchBar.text = ""
         return true


### PR DESCRIPTION
## 変更の概要
### プログラミング構造をリファクタリング #5 
以下の原則を参考にプログラムをリファクタリング
* DRY原則
* CQS原則
* 単一責任原則
* インターフェイス分離の原則
* 驚き最小の原則

## 変更内容

### 共通
* 関数にスコープを設定

### `SearchRepositoryViewController.swift`
* `searchBarSearchButtonClicked()`に書かれていたリポジトリの検索処理を`searchRepository()`として分離
* `viewDidLoad()`内のSearchBarとPresenterの初期化処理をそれぞれ`setupSearchBar()`と`setupPresenter()`として分離
* 検索をキャンセルする`urlSessionTask?.cancel()`をPresenterに`cancelURLSession()`として移動

### `SearchRepositoryPresenter.swift`
* `searchRepositories`の責務を切り分け
  - APIのURLを構築する`createAPIURL()`
  - URLセッションを行う`urlSession()`
  - データのパース処理を行う`parseData()`
* `parseImageData()`の追加に伴い`parseData()`を`parseRepositoryData()`に変更
* URLセッションのキャンセルを行う`cancelURLSession()`を追加

### `DetailRepositoryViewController.swift`
* `extension`で`DetailRepositoryViewController`クラスを分割した
* リポジトリの情報をUIに反映する処理を`updateUI()`として分離
* `getImage()`内のURLセッション処理を`parseImageData()`として分離
* `selectedRowIndex`のアンラップ処理が`getImage()`内と外で重複していたため、`getImage(_ selectedRowIndex: Int)`とし、関数内部のアンラップ処理を削除した

## 備考
* ChatGPTの使用
  - 切り分けを行なっていく中でエラーが発生した際に、何が原因でエラーが起きているかを質問した
  - コードのリファクタリングを依頼した（`cancelURLSession()`はこの質問から得られた回答を参考に追加した）

close #5 